### PR TITLE
Tidy up the output from pin_throw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ inst/rmd/rsconnect
 kingpin.Rcheck/
 kingpin*.tar.gz
 kingpin*.tgz
+.Rhistory

--- a/R/pin_throw.R
+++ b/R/pin_throw.R
@@ -53,11 +53,9 @@ pin_throw <- function(board,
 
   # If comment is still NULL:
   if (is.null(comment)) {
-    message("Pin will be pinned with no description. Please consider adding a description using the `comment` argument.")
-    comment <- NA } else { # If comment is not NULL
-      cat("Pinned", name, "with the description '", comment(file), "'.")
-    }
-
+    comment <- NA
+  }
+  
   # Get active project
   call <- purrr::safely(rstudioapi::getActiveProject)()
   if(is.null(call$result) | !is.null(call$error)) { # If not in a project or not in a session
@@ -75,6 +73,12 @@ pin_throw <- function(board,
   access <- suppressMessages(purrr::safely(pins::pin_write)(board, file, name, description = desc, ...))
   if (is.null(access$result)) { stop("Error occured during pinning.") }
 
+  if (is.na(comment)){
+    message("Pinned with no description. Please consider adding a description using the `comment` argument.")
+  } else {
+    message("Pinned", name, "with the description '", comment(file), "'.")
+  }
+  
   if(!is.null(old_info$error)){ # If old pin doesnt exist yet/error in collecting pin, it has no size
 
     modified <- NA


### PR DESCRIPTION
Move the messages about the description etc so that they are run after the pinning is successful (otherwise you get told that you have pinned something but the pinning process caused an error)

Switched from `cat` to `message` to better match with other R functions (like suppressMessages)